### PR TITLE
Add GOBIN to dev environment setup

### DIFF
--- a/tips/tip-6-golang-style-guide.md
+++ b/tips/tip-6-golang-style-guide.md
@@ -25,7 +25,8 @@ For reference, here's what a development environment looks like:
     cat ~/GO_ENV 
     export GOROOT=$HOME/go
     export GOPATH=$HOME/GO_LIBS
-    export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+    export GOBIN=$GOROOT/bin
+    export PATH=$GOBIN:$GOPATH/bin:$PATH
     export PS1="(go) $PS1"
 
 These settings can be loaded by adding `. ~/GO_ENV` to your `.bashrc`


### PR DESCRIPTION
Avoids this issue on OSX:

`go install: no install location for directory /Users/... outside GOPATH`